### PR TITLE
feat: select 컴포넌트 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@toss/use-overlay": "^1.3.1",
     "axios": "1.3.3",
     "next": "13.1.6",
-    "pnpm": "^7.27.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-error-boundary": "3.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,6 @@ specifiers:
   jest-environment-jsdom: ^29.4.3
   lint-staged: 13.1.2
   next: 13.1.6
-  pnpm: ^7.27.0
   prettier: 2.8.4
   react: 18.2.0
   react-dom: 18.2.0
@@ -54,7 +53,6 @@ dependencies:
   '@toss/use-overlay': 1.3.1_react@18.2.0
   axios: 1.3.3
   next: 13.1.6_biqbaboplfbrettd7655fr4n2y
-  pnpm: 7.27.1
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
   react-error-boundary: 3.1.4_react@18.2.0
@@ -6393,12 +6391,6 @@ packages:
     dependencies:
       find-up: 4.1.0
     dev: true
-
-  /pnpm/7.27.1:
-    resolution: {integrity: sha512-IpBeZ+71slENbuOXwbV4U6yxOMfEWEvlVuT6+ChZ1D80oF0eHyN4h/hc13UrzVXpXI3bf7sPfRWGb8TYkrvJUA==}
-    engines: {node: '>=14.6'}
-    hasBin: true
-    dev: false
 
   /postcss/8.4.14:
     resolution: {integrity: sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==}

--- a/src/components/common/Select/Select.tsx
+++ b/src/components/common/Select/Select.tsx
@@ -1,0 +1,64 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import type { PropsWithChildren } from 'react';
+
+import useCategorySelect from '~/hooks/useCategorySelect';
+import { theme } from '~/styles/Theme';
+
+import { Icon } from '../Icon';
+
+interface SelectItemProps {
+  id: number;
+}
+
+const SelectItem = ({ id, children }: PropsWithChildren<SelectItemProps>) => {
+  const { selected, handleCategorySelect } = useCategorySelect({ type: 'main', categoryId: id });
+
+  return (
+    <StyledSelectItem selected={selected} onClick={handleCategorySelect}>
+      <p css={SelectItemStyle}>{children}</p>
+      {selected && <Icon size="eachSize" width={18} height={14} iconName="check" />}
+    </StyledSelectItem>
+  );
+};
+
+interface SelectProps {
+  items: MainCategoryResponse[];
+}
+
+const Select = ({ items }: SelectProps) => {
+  return (
+    <ul>
+      {items.map(item => (
+        <SelectItem key={item.id} id={item.id}>
+          {item.name}
+        </SelectItem>
+      ))}
+    </ul>
+  );
+};
+
+export default Select;
+
+type SelectStyleProps = { selected: boolean };
+
+const StyledSelectItem = styled('li')<SelectStyleProps>`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 5.6rem;
+  border-radius: 0.8rem;
+  padding: 1.6rem;
+  background-color: ${theme.color.gray000};
+  color: ${theme.color.gray800};
+
+  ${({ selected }) =>
+    selected &&
+    css`
+      border: 2px solid ${theme.color.primary_default};
+    `}
+`;
+
+const SelectItemStyle = css`
+  ${theme.typography.b1}
+`;

--- a/src/components/common/Select/Select.tsx
+++ b/src/components/common/Select/Select.tsx
@@ -52,6 +52,10 @@ const StyledSelectItem = styled('li')<SelectStyleProps>`
   background-color: ${theme.color.gray000};
   color: ${theme.color.gray800};
 
+  :not(:first-child) {
+    margin-top: 1rem;
+  }
+
   ${({ selected }) =>
     selected &&
     css`

--- a/src/components/common/Select/index.ts
+++ b/src/components/common/Select/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Select';

--- a/src/hooks/useCategorySelect.ts
+++ b/src/hooks/useCategorySelect.ts
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import { useRecoilState } from 'recoil';
+
+import selectedCategoryIdAtomFamily from '~/store/selectedCategoryId/selectedCategoryIdAtom';
+
+import { useDidUpdate } from './useDidUpdate';
+
+type CategoryType = 'main' | 'mid';
+
+interface UseCategorySelectProps {
+  type: CategoryType;
+  categoryId: number;
+}
+
+const useCategorySelect = ({ type, categoryId }: UseCategorySelectProps) => {
+  const [selectedId, setSelectedId] = useRecoilState(selectedCategoryIdAtomFamily(type));
+  const [selected, setSelected] = useState(false);
+
+  useDidUpdate(() => {
+    categoryId === selectedId ? setSelected(true) : setSelected(false);
+  }, [selectedId]);
+
+  const handleCategorySelect = () => {
+    setSelectedId(categoryId);
+  };
+
+  return { selected, handleCategorySelect };
+};
+
+export default useCategorySelect;

--- a/src/hooks/useDidMount.ts
+++ b/src/hooks/useDidMount.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+
+import type { CallbackWithNoArguments } from '~/types';
+
+const useDidMount = (callback: CallbackWithNoArguments): void => {
+  useEffect(() => {
+    if (typeof callback === 'function') {
+      callback();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+};
+
+export default useDidMount;

--- a/src/hooks/useDidUpdate.ts
+++ b/src/hooks/useDidUpdate.ts
@@ -1,0 +1,36 @@
+import { useEffect, useMemo, useRef } from 'react';
+
+import useDidMount from './useDidMount';
+import useWillUnmount from './useWillUnmount';
+
+function useDidUpdate(callback: () => void, conditions?: unknown[]): void {
+  const hasMountedRef = useRef<boolean>(false);
+  const internalConditions = useMemo(() => {
+    if (typeof conditions !== 'undefined' && !Array.isArray(conditions)) {
+      return [conditions];
+    } else if (Array.isArray(conditions) && conditions.length === 0) {
+      console.warn(
+        'Using [] as the second argument makes useDidUpdate a noop. The second argument should either be `undefined` or an array of length greater than 0.'
+      );
+    }
+
+    return conditions;
+  }, [conditions]);
+
+  useEffect(() => {
+    if (hasMountedRef.current) {
+      callback();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, internalConditions);
+
+  useDidMount(() => {
+    hasMountedRef.current = true;
+  });
+
+  useWillUnmount(() => {
+    hasMountedRef.current = false;
+  });
+}
+
+export { useDidUpdate };

--- a/src/hooks/useWillUnmount.ts
+++ b/src/hooks/useWillUnmount.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+import type { CallbackWithNoArguments } from '~/types';
+
+const useWillUnmount = (callback: CallbackWithNoArguments): void => {
+  useEffect(() => {
+    return callback;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+};
+
+export default useWillUnmount;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,21 @@
 import Button from '~/components/common/Button';
+import { Input } from '~/components/common/Input';
+import Select from '~/components/common/Select';
 import Text from '~/components/common/Text';
 
 export default function Home() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <div>Home</div>
+      <div style={{ width: '328px' }}>
+        <Select
+          items={[
+            { id: 1, name: '프론트엔드' },
+            { id: 2, name: '백엔드' },
+            { id: 3, name: '데브옵스' },
+          ]}
+        />
+      </div>
       <Text variant="h1">이팩티브 기술면접</Text>
       <Text variant="h2">이팩티브 기술면접</Text>
       <Text variant="b1">이팩티브 기술면접</Text>
@@ -32,6 +43,7 @@ export default function Home() {
         </Button>
         <Button backgroundColor="system_error">버튼</Button>
       </div>
+      <Input></Input>
     </div>
   );
 }

--- a/src/store/selectedCategoryId/index.ts
+++ b/src/store/selectedCategoryId/index.ts
@@ -1,0 +1,1 @@
+export { default } from './selectedCategoryIdAtom';

--- a/src/store/selectedCategoryId/selectedCategoryIdAtom.ts
+++ b/src/store/selectedCategoryId/selectedCategoryIdAtom.ts
@@ -1,0 +1,8 @@
+import { atomFamily } from 'recoil';
+
+const selectedCategoryIdAtomFamily = atomFamily({
+  key: 'selectedCategoryId',
+  default: 0,
+});
+
+export default selectedCategoryIdAtomFamily;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export type { CallbackWithNoArguments } from './types';

--- a/src/types/response.d.ts
+++ b/src/types/response.d.ts
@@ -1,0 +1,4 @@
+interface MainCategoryResponse {
+  id: number;
+  name: string;
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,0 +1,1 @@
+export type CallbackWithNoArguments = () => void;


### PR DESCRIPTION
## 🚀 작업 내용
<!-- 작업한 사항을 간략하게 적어주세요 -->
1. `useDidMount`, `useDidUpdate`, `useWillUnmount` 훅을 추가했어요.
2. 필요한 `type`을 정의했어요.
3. `useCategorySelect` hook, `Select` 컴포넌트를 추가했어요.
4. `pnpm` 패키지를 제거했어요.

## ✏️ 상세 설명
<!-- 추가 설명이 필요한 경우 작성해주세요 -->
### 2. 필요한 `type`을 정의했어요.
- 공통으로 사용하게 될 type을 `types` 폴더 안에 정의했어요.
- response의 경우 `response.d.ts` 파일 안에 정의했어요.

### 3. `useCategorySelect`, `Select` 컴포넌트를 추가했어요.
- 다음과 같이 사용할 수 있어요.
```javascript
<Select items={[{ id: 1, name: '프론트엔드' }, { id: 2, name: '백엔드' }, { id: 3, name: '데브옵스' }]} />
```

## 📷 스크린샷
<!-- 스크린샷으로 작업 내용을 알려주세요 -->
https://user-images.githubusercontent.com/79739512/220176222-5af4d22c-257d-4f53-b185-6034a5945758.mov

## 📁 참고 자료
<!-- 참고한 자료가 있다면 공유주세요 -->