### PR TITLE
feat: 로그인 로직 작업 완료 및 비밀번호 재설정 레이아웃

### DIFF
--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -138,10 +138,7 @@ axiosClient.interceptors.response.use(
       try {
         const {
           data: { accessToken, refreshToken },
-        } = await axios.post(
-          'http://fteam-env-1.eba-ciibaeid.ap-northeast-2.elasticbeanstalk.com/api/v1/auth/refresh',
-          { headers }
-        );
+        } = await axios.post(`${DEV_SERVER_URL}/auth/refresh`, { headers });
         if (error?.config?.headers === undefined) {
           return null;
         } else {

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -33,7 +33,7 @@ export const Header = ({ headerTitle, color }: HeaderProps) => {
   );
 };
 
-const HeaderWrapper = styled.div<{ color: ColorType }>`
+export const HeaderWrapper = styled.div<{ color: ColorType }>`
   display: flex;
   height: 64px;
   width: calc(100% + 16 * 2);
@@ -48,6 +48,6 @@ const HeaderWrapper = styled.div<{ color: ColorType }>`
   }};
 `;
 
-const IconContainer = styled.div`
+export const IconContainer = styled.div`
   cursor: pointer;
 `;

--- a/src/components/common/Toast/index.tsx
+++ b/src/components/common/Toast/index.tsx
@@ -28,7 +28,7 @@ const StyledToast = styled.div`
   left: 50%;
   transform: translate(-50%, 0);
 
-  width: fit-content;
+  width: 90%;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/homePage/HomeHeader/index.tsx
+++ b/src/components/homePage/HomeHeader/index.tsx
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled';
+
+import { IconContainer } from '~/components/common/Header';
+import { Icon } from '~/components/common/Icon';
+import { useShowLoginModal } from '~/hooks/useShowLoginModal';
+
+export const HomeHeader = () => {
+  const showLoginModal = useShowLoginModal();
+  return (
+    <HomeHeaderWrapper>
+      <IconContainer>
+        <img
+          alt="blue-logo"
+          width={30}
+          src="https://effectivetechinterview-asset.s3.ap-northeast-1.amazonaws.com/logo-blue.svg"
+        />
+      </IconContainer>
+      <IconContainer onClick={showLoginModal}>
+        <Icon iconName="user" />
+      </IconContainer>
+    </HomeHeaderWrapper>
+  );
+};
+
+const HomeHeaderWrapper = styled.div`
+  display: flex;
+  height: 64px;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+`;

--- a/src/constants/validationPattern.ts
+++ b/src/constants/validationPattern.ts
@@ -1,4 +1,6 @@
 // eslint-disable-next-line no-useless-escape
 export const emailPattern = new RegExp(/^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/i);
 
-export const passwordPattern = new RegExp(/^[A-Za-z0-9]*$/i);
+export const passwordPattern = new RegExp(/^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$/i);
+
+export const verificatonPattern = new RegExp(/^[0-9]+$/i);

--- a/src/hooks/form/useCheckLoginForm.ts
+++ b/src/hooks/form/useCheckLoginForm.ts
@@ -49,16 +49,15 @@ export const useCheckLoginForm = () => {
     const { email, password } = getValues();
     try {
       const data = await postLogin(email, password);
-      console.log(data);
       if (data) {
         const { accessToken, refreshToken } = data;
         localStorage.setItem('accessToken', accessToken);
         localStorage.setItem('refreshToken', refreshToken);
       }
       if (authToken.access && authToken.refresh) {
+        // TODO: 리다이렉트 페이지 바꾸기
         router.push('/');
       }
-      //로컬스토리지에 제대로 aT, rT 들어갔으면 카테고리 선택 페이지로 라우팅
     } catch (error: unknown) {
       if (isEffError(error)) {
         // TODO: toast 추가
@@ -66,7 +65,6 @@ export const useCheckLoginForm = () => {
           type: 'danger',
           title: '이메일 또는 비밀번호가 다릅니다',
         });
-        console.log(error.message, error.errorCode);
       }
     }
   });

--- a/src/hooks/form/useCheckSignUpForm.tsx
+++ b/src/hooks/form/useCheckSignUpForm.tsx
@@ -6,9 +6,10 @@ import { useForm } from 'react-hook-form';
 import { postEmail, postEmailAndCode, postSignUp } from '~/apis';
 import { isEffError } from '~/apis/client';
 import { ConfirmModal } from '~/components/common/ConfirmModal';
-import { emailPattern, passwordPattern } from '~/constants/validationPattern';
+import { emailPattern, passwordPattern, verificatonPattern } from '~/constants/validationPattern';
 
 import { useModal } from '../useModal';
+import { useToast } from '../useToast';
 
 interface CheckSignUpForm {
   email: string;
@@ -27,6 +28,7 @@ export const useCheckSignUpForm = () => {
   } = useForm<CheckSignUpForm>({ mode: 'onBlur' });
   const router = useRouter();
   const { openModal } = useModal();
+  const { openToast } = useToast();
 
   const isDisabled = !isDirty || !isValid;
 
@@ -60,7 +62,14 @@ export const useCheckSignUpForm = () => {
   const isPasswordPattern = useCallback(() => {
     return {
       value: passwordPattern,
-      message: '숫자와 영문만 입력해주세요.',
+      message: '숫자와 영문 조합으로 입력해주세요.',
+    };
+  }, []);
+
+  const isVerificationpattern = useCallback(() => {
+    return {
+      value: verificatonPattern,
+      message: '숫자만 입력해주세요.',
     };
   }, []);
 
@@ -71,22 +80,27 @@ export const useCheckSignUpForm = () => {
       postEmail(email);
     } catch (error: unknown) {
       if (isEffError(error)) {
-        // TODO: toast 추가
-        console.log(error.message, error.errorCode);
+        await openToast({
+          type: 'danger',
+          title: `${error.message}`,
+        });
       }
     }
   });
 
   const { mutate: checkVerificationCodeMutation } = useMutation(async () => {
     const { email, verificationCode } = getValues();
+    console.log(verificationCode, typeof verificationCode);
 
     try {
       await postEmailAndCode(email, verificationCode);
       router.push(`/signup/password/${email}`);
     } catch (error: unknown) {
       if (isEffError(error)) {
-        // TODO: toast 추가
-        console.log(error.message, error.errorCode);
+        await openToast({
+          type: 'danger',
+          title: `${error.message}`,
+        });
       }
     }
   });
@@ -101,8 +115,10 @@ export const useCheckSignUpForm = () => {
       });
     } catch (error: unknown) {
       if (isEffError(error)) {
-        // TODO: toast 추가
-        console.log(error.message, error.errorCode);
+        await openToast({
+          type: 'danger',
+          title: `${error.message}`,
+        });
       }
     }
   });
@@ -122,5 +138,6 @@ export const useCheckSignUpForm = () => {
     isEmailPattern,
     isPasswordPattern,
     isMaxLength,
+    isVerificationpattern,
   };
 };

--- a/src/hooks/useShowLoginModal.tsx
+++ b/src/hooks/useShowLoginModal.tsx
@@ -1,0 +1,26 @@
+import { useRouter } from 'next/router';
+
+import { authToken } from '~/apis/client';
+import { ConfirmModal } from '~/components/common/ConfirmModal';
+
+import { useModal } from './useModal';
+
+export function useShowLoginModal() {
+  const { openModal } = useModal();
+  const router = useRouter();
+
+  const showLoginModal = async () => {
+    if (authToken.access && authToken.refresh) {
+      // TODO: 리다이렉트 페이지 바꾸기
+      router.push('/');
+    } else {
+      await openModal({
+        children: (
+          <ConfirmModal title="로그인이 필요해요" subtitle="회원가입 후 연습을 시작할 수 있어요" />
+        ),
+      });
+    }
+  };
+
+  return showLoginModal;
+}

--- a/src/pages/find/[email]/index.tsx
+++ b/src/pages/find/[email]/index.tsx
@@ -6,7 +6,6 @@ import { Header } from '~/components/common/Header';
 import { Icon } from '~/components/common/Icon';
 import { Input } from '~/components/common/Input';
 import Text from '~/components/common/Text';
-import { useCheckSignUpForm } from '~/hooks/form/useCheckSignUpForm';
 
 type IParams = {
   email: string;
@@ -21,22 +20,9 @@ export async function getServerSideProps({ params }: { params: IParams }) {
   };
 }
 
-export default function Password({ email }: { email: string }) {
+export default function ResetPassword({ email }: { email: string }) {
   const [isVisible, setIsVisible] = useState(false);
   const [isCheckVisible, setIsCheckVisible] = useState(false);
-
-  const {
-    register,
-    completeSignUpMutation,
-    isPasswordPattern,
-    isMinLength,
-    getValues,
-    isMaxLength,
-    isRequiredText,
-    errors,
-    isDisabled,
-  } = useCheckSignUpForm();
-
   const handleVisible = () => {
     setIsVisible(prev => !prev);
   };
@@ -46,25 +32,12 @@ export default function Password({ email }: { email: string }) {
   };
   return (
     <>
-      <Header headerTitle="회원가입" color="white" />
+      <Header headerTitle="비밀번호 찾기" color="white" />
       <Spacing size={40} />
-      <form
-        onSubmit={e => {
-          e.preventDefault();
-          completeSignUpMutation(email);
-        }}
-      >
+      <form>
         <Input
-          isVisible={isVisible}
-          label="비밀번호"
+          label="비밀번호 재설정"
           placeholder="비밀번호 (영문, 숫자 조합 8자 이상)"
-          errorMessage={errors.password?.message}
-          {...register('password', {
-            required: isRequiredText('비밀번호'),
-            pattern: isPasswordPattern(),
-            minLength: isMinLength(8),
-            maxLength: isMaxLength(20),
-          })}
           suffix={
             isVisible ? (
               <Icon onClick={handleVisible} iconName="show" />
@@ -75,19 +48,8 @@ export default function Password({ email }: { email: string }) {
         />
         <Spacing size={40} />
         <Input
-          isVisible={isCheckVisible}
-          label="비밀번호 확인"
+          label="비밀번호 재설정 확인"
           placeholder="비밀번호를 입력해주세요."
-          errorMessage={errors.confirmPassword?.message}
-          {...register('confirmPassword', {
-            required: isRequiredText('비밀번호'),
-            validate: {
-              matchPassword: value => {
-                const { password } = getValues();
-                return password === value || '비밀번호가 일치하지 않습니다. ';
-              },
-            },
-          })}
           suffix={
             isCheckVisible ? (
               <Icon onClick={handleCheckVisible} iconName="show" />
@@ -97,11 +59,12 @@ export default function Password({ email }: { email: string }) {
           }
         />
         <Spacing size={40} />
-        <Button variant="largePrimary" disabled={isDisabled}>
-          가입 완료
+        <Button variant="largePrimary" disabled={false}>
+          변경 완료
         </Button>
       </form>
       <Spacing size={144} />
+
       <Flex.Center direction="column">
         <Text variant="b2" color="gray400">
           회원가입 시, 이펙티브 기술면접 서비스 이용

--- a/src/pages/find/index.tsx
+++ b/src/pages/find/index.tsx
@@ -1,0 +1,49 @@
+import { Flex, Spacing } from '@toss/emotion-utils';
+
+import Button from '~/components/common/Button';
+import { Header } from '~/components/common/Header';
+import { Input } from '~/components/common/Input';
+import Text from '~/components/common/Text';
+
+export default function Find() {
+  return (
+    <>
+      <Header headerTitle="비밀번호 찾기" color="white" />
+      <Spacing size={40} />
+      <form>
+        <Input
+          placeholder="가입한 이메일을 입력해주세요"
+          label="가입한 이메일 입력"
+          suffix={
+            <Button
+              // onClick={(e: React.SyntheticEvent) => sendCode(e)}
+              width={10}
+              height={3.1}
+              variant="smallButton"
+            >
+              인증코드 전송
+            </Button>
+          }
+        />
+        <Spacing size={8} />
+        <Input placeholder="인증 번호 6자리" />
+        <Spacing size={40} />
+        <Button variant="largePrimary" disabled={false}>
+          완료
+        </Button>
+      </form>
+      <Spacing size={40} />
+      <Text variant="b2">인증번호가 오지 않나요?</Text>
+      <Spacing size={8} />
+      <Flex direction="column">
+        <Text variant="b2" color="gray400">
+          스팸메일함을 확인해주세요. 스팸메일함에도 없다면 다시한번 ‘인증번호 전송’을 눌러주세요.
+        </Text>
+        <Spacing size={8} />
+        <Text variant="b2" color="gray400">
+          계정문의 | effectivetechinterview@gmail.com
+        </Text>
+      </Flex>
+    </>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,29 +1,33 @@
 import { Flex, Spacing } from '@toss/emotion-utils';
 
 import Button from '~/components/common/Button';
-import { ConfirmModal } from '~/components/common/ConfirmModal';
 import Text from '~/components/common/Text';
-import { useModal } from '~/hooks/useModal';
+import { HomeHeader } from '~/components/homePage/HomeHeader';
+import { useShowLoginModal } from '~/hooks/useShowLoginModal';
 
 export default function Home() {
-  const { openModal } = useModal();
-
-  const onClick = async () => {
-    await openModal({
-      children: (
-        <ConfirmModal title="로그인이 필요해요" subtitle="회원가입 후 연습을 시작할 수 있어요" />
-      ),
-    });
-  };
+  const showLoginModal = useShowLoginModal();
   return (
     <Flex.Center direction="column">
+      <HomeHeader />
+      <img
+        alt="korean-logo"
+        width={224}
+        src="https://effectivetechinterview-asset.s3.ap-northeast-1.amazonaws.com/logo-korean.svg"
+      />
+      <Spacing size={16} />
       <Text variant="b1" color="gray600">
         AI 꼬리질문으로 준비하는 면접 연습
       </Text>
       <Spacing size={24} />
-      {/* 메인 화면 이미지 */}
+      <img
+        alt="main-page-image"
+        width={328}
+        height={328}
+        src="https://effectivetechinterview-asset.s3.ap-northeast-1.amazonaws.com/mainPage.png"
+      />
       <Spacing size={24} />
-      <Button variant="largePrimary" onClick={onClick}>
+      <Button variant="largePrimary" onClick={showLoginModal}>
         시작하기
       </Button>
     </Flex.Center>

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,19 +1,26 @@
+import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { Flex, Spacing } from '@toss/emotion-utils';
 
 import Button from '~/components/common/Button';
 import { Header } from '~/components/common/Header';
+import { Icon } from '~/components/common/Icon';
 import { Input } from '~/components/common/Input';
 import Text from '~/components/common/Text';
 import { useCheckLoginForm } from '~/hooks/form/useCheckLoginForm';
 
 export default function Login() {
   const router = useRouter();
+  const [isVisible, setIsVisible] = useState(false);
 
   const { isDisabled, register, isEmailPattern, isPasswordPattern, loginMutation, isRequiredText } =
     useCheckLoginForm();
   const onClick = () => {
     router.push('/signup');
+  };
+
+  const handleVisible = () => {
+    setIsVisible(prev => !prev);
   };
   return (
     <>
@@ -35,12 +42,20 @@ export default function Login() {
         />
         <Spacing size={32} />
         <Input
+          isVisible={isVisible}
           label="비밀번호"
           placeholder="비밀번호(영문, 숫자 조합 8자 이상)"
           {...register('password', {
             pattern: isPasswordPattern(),
             required: isRequiredText('비밀번호'),
           })}
+          suffix={
+            isVisible ? (
+              <Icon onClick={handleVisible} iconName="show" />
+            ) : (
+              <Icon onClick={handleVisible} iconName="hide" />
+            )
+          }
         />
         <Spacing size={40} />
         <Button variant="largePrimary" disabled={isDisabled}>
@@ -57,17 +72,11 @@ export default function Login() {
         >
           회원가입
         </Text>
-        <Text variant="subtitle">비밀번호 찾기</Text>
+        <Text variant="subtitle" onClick={() => router.push('/find')}>
+          비밀번호 찾기
+        </Text>
       </Flex.Center>
       <Spacing size={124} />
-      <Flex.Center direction="column">
-        <Text variant="b2" color="gray400">
-          회원가입 시, 이펙티브 기술면접 서비스 이용
-        </Text>
-        <Text variant="b2" color="gray400">
-          약관과 개인정보 보호정책에 동의하게 됩니다.
-        </Text>
-      </Flex.Center>
     </>
   );
 }

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,4 +1,4 @@
-import { Spacing } from '@toss/emotion-utils';
+import { Flex, Spacing } from '@toss/emotion-utils';
 
 import Button from '~/components/common/Button';
 import { Header } from '~/components/common/Header';
@@ -15,6 +15,9 @@ export default function SignUp() {
     checkVerificationCodeMutation,
     isRequiredText,
     isEmailPattern,
+    isMaxLength,
+    isMinLength,
+    isVerificationpattern,
   } = useCheckSignUpForm();
 
   const sendCode = (e: React.SyntheticEvent) => {
@@ -57,6 +60,9 @@ export default function SignUp() {
           errorMessage={errors.verificationCode?.message}
           {...register('verificationCode', {
             required: isRequiredText('인증번호'),
+            pattern: isVerificationpattern(),
+            maxLength: isMaxLength(6),
+            minLength: isMinLength(6),
           })}
         />
         <Spacing size={40} />
@@ -67,9 +73,15 @@ export default function SignUp() {
       <Spacing size={40} />
       <Text variant="b2">인증번호가 오지 않나요?</Text>
       <Spacing size={8} />
-      <Text variant="b2" color="gray400">
-        스팸메일함을 확인해주세요. 스팸메일함에도 없다면 다시한번 ‘인증번호 전송’을 눌러주세요.
-      </Text>
+      <Flex direction="column">
+        <Text variant="b2" color="gray400">
+          스팸메일함을 확인해주세요. 스팸메일함에도 없다면 다시한번 ‘인증번호 전송’을 눌러주세요.
+        </Text>
+        <Spacing size={8} />
+        <Text variant="b2" color="gray400">
+          계정문의 | effectivetechinterview@gmail.com
+        </Text>
+      </Flex>
     </>
   );
 }


### PR DESCRIPTION
## 🚀 작업 내용
<!-- 작업한 사항을 간략하게 적어주세요 -->
- 온보딩 페이지 로고와 이미지를 적영했습니다. 
- 로그인 로직 작업을 완료했습니다. (이부분은 rT랑 aT 만료시간 줄여서 백이랑 테스트 한번 해봐야 할 것 같긴 해요!!)
- 비밀번호 찾기 페이지 레이아웃 작업을 완료했습니다. 

## ✏️ 상세 설명
<!-- 추가 설명이 필요한 경우 작성해주세요 -->
- 홈 화면 이미지 넣으면서 s3 버킷을 생성해두었습니다. 
https://s3.console.aws.amazon.com/s3/buckets/effectivetechinterview-asset?region=ap-northeast-1&tab=objects

## 📁 참고 자료
<!-- 참고한 자료가 있다면 공유주세요 -->