### PR TITLE
feat: category detail 페이지 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,14 @@ const nextConfig = {
 
     return config;
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: process.env.NEXT_PUBLIC_DEVELOPMENT_S3_HOST_NAME,
+      },
+    ],
+  },
 };
 
 module.exports = nextConfig;

--- a/next.config.js
+++ b/next.config.js
@@ -18,7 +18,7 @@ const nextConfig = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: process.env.NEXT_PUBLIC_DEVELOPMENT_S3_HOST_NAME,
+        hostname: 'sparcs-2023-startup-hackathon-f-1.s3.ap-northeast-2.amazonaws.co',
       },
     ],
   },

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -13,6 +13,15 @@ export const getMainCategories = async () => {
   return { categories };
 };
 
+export const getMidCategories = async (mainCategoryId: number) => {
+  const {
+    data: { name, categories },
+  } = await axiosClient.get<MidCategoriesResponse>('/categories/mid', {
+    params: { mainCategoryId },
+  });
+  return { name, categories };
+};
+
 export async function postEmail(email: string) {
   return await axiosClient.post('/auth/email/send', { email });
 }

--- a/src/components/categoryDetail/CategoryDetailBody.tsx
+++ b/src/components/categoryDetail/CategoryDetailBody.tsx
@@ -1,0 +1,37 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { css } from '@emotion/react';
+
+interface CategoryDetailBodyProps {
+  categories?: MidCategoryResponse[];
+}
+
+const CategoryDetailBody = ({ categories }: CategoryDetailBodyProps) => {
+  return (
+    <div css={CategoryDetailBodyWrapperStyle}>
+      {categories?.map(category => {
+        return (
+          <div key={category.id} css={CategoryDetailBodyImgWrapperStyle}>
+            <Link href={`/questions/${category.name.toLowerCase()}`}>
+              <Image alt={category.name} src={category.imageUrl} fill />
+            </Link>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export { CategoryDetailBody };
+
+const CategoryDetailBodyWrapperStyle = css`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.8rem;
+`;
+
+const CategoryDetailBodyImgWrapperStyle = css`
+  position: relative;
+  width: 100%;
+  height: 160px;
+`;

--- a/src/components/categoryDetail/CategoryDetailHeader.tsx
+++ b/src/components/categoryDetail/CategoryDetailHeader.tsx
@@ -1,0 +1,33 @@
+import { useRouter } from 'next/router';
+import { Flex, Spacing } from '@toss/emotion-utils';
+
+import Button from '../common/Button';
+import Text from '../common/Text';
+
+interface CategoryDetailHeaderProps {
+  name?: string;
+}
+
+const CategoryDetailHeader = ({ name }: CategoryDetailHeaderProps) => {
+  const router = useRouter();
+
+  return (
+    <Flex direction="column" justify="space-between">
+      <Text variant="b1">나의 희망 직무</Text>
+      <Spacing size={8} />
+      <Flex align="center" justify="space-between">
+        <Text variant="h2">{name}</Text>
+        <Button
+          variant="mediumTeritary"
+          width={6}
+          height={4}
+          onClick={() => router.push('/category')}
+        >
+          변경
+        </Button>
+      </Flex>
+    </Flex>
+  );
+};
+
+export { CategoryDetailHeader };

--- a/src/components/categoryDetail/index.ts
+++ b/src/components/categoryDetail/index.ts
@@ -1,0 +1,2 @@
+export { CategoryDetailBody } from './CategoryDetailBody';
+export { CategoryDetailHeader } from './CategoryDetailHeader';

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,3 +1,9 @@
 export const MAIN_CATEGORY_QUERY_KEYS = {
   getMainCategories: ['getMainCategories'],
 };
+
+export const MID_CATEGORY_QUERY_KEYS = {
+  getMidCategories(mainCategoryId: number) {
+    return ['getMidCategories', mainCategoryId];
+  },
+};

--- a/src/hooks/query/useMidCategoryQuery.ts
+++ b/src/hooks/query/useMidCategoryQuery.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getMidCategories } from '~/apis';
+import { MID_CATEGORY_QUERY_KEYS } from '~/constants/queryKeys';
+
+export const useMidCategoryQuery = (mainCategoryId: number) => {
+  const midCategoryQuery = useQuery({
+    queryKey: MID_CATEGORY_QUERY_KEYS.getMidCategories(mainCategoryId),
+    queryFn: () => getMidCategories(mainCategoryId),
+  });
+  return midCategoryQuery;
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -24,7 +24,7 @@ export default function App({ Component, pageProps }: AppProps<PageProps>) {
         <OverlayProvider>
           <QueryErrorBoundary ErrorFallback={GlobalErrorFallback}>
             <RecoilDebugObserver />
-            <ClientSuspense fallback={<>Global Suspense</>}>
+            <ClientSuspense fallback={<></>}>
               <ThemeProvider theme={theme}>
                 <GlobalStyle />
                 <Layout>

--- a/src/pages/category/[categoryId]/index.tsx
+++ b/src/pages/category/[categoryId]/index.tsx
@@ -1,3 +1,67 @@
-export default function CategoryDetail() {
-  return <div>CategoryDetail</div>;
+import type { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from 'next';
+import type { DehydratedState } from '@tanstack/react-query';
+import { dehydrate, QueryClient } from '@tanstack/react-query';
+import { Flex, Spacing } from '@toss/emotion-utils';
+
+import { getMidCategories } from '~/apis';
+import { CategoryDetailBody, CategoryDetailHeader } from '~/components/categoryDetail';
+import Text from '~/components/common/Text';
+import { MID_CATEGORY_QUERY_KEYS } from '~/constants/queryKeys';
+import { useMidCategoryQuery } from '~/hooks/query/useMidCategoryQuery';
+
+const TOTAL_PAGE_NUMBER = 4;
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  // TODO: getMainCategories API를 통한 개선점 존재
+  const paths = Array(TOTAL_PAGE_NUMBER)
+    .fill(0)
+    .map((_, index) => {
+      return { params: { categoryId: `${index + 1}` } };
+    });
+
+  return { paths, fallback: false };
+};
+
+export const getStaticProps: GetStaticProps<{
+  mainCategoryId: number;
+  dehydratedState: DehydratedState;
+}> = async ({ params }) => {
+  let mainCategoryId = 0;
+
+  const queryClient = new QueryClient();
+
+  if (params && params.categoryId) {
+    mainCategoryId = Number(params.categoryId);
+
+    await queryClient.prefetchQuery({
+      queryKey: MID_CATEGORY_QUERY_KEYS.getMidCategories(mainCategoryId),
+      queryFn: () => getMidCategories(mainCategoryId),
+    });
+  }
+
+  return {
+    props: { mainCategoryId, dehydratedState: dehydrate(queryClient) },
+  };
+};
+
+export default function CategoryDetail({
+  mainCategoryId,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
+  const { data } = useMidCategoryQuery(mainCategoryId);
+
+  return (
+    <>
+      {/* { TODO: Add Header} */}
+      <Spacing size={26} />
+      <CategoryDetailHeader name={data?.name} />
+      <Spacing size={20} />
+      <CategoryDetailBody categories={data?.categories} />
+      <Spacing size={63} />
+      <Flex.Center>
+        <Text variant="caption" color="gray400">
+          effectivetechinterview@gmail.com
+        </Text>
+      </Flex.Center>
+    </>
+  );
 }

--- a/src/pages/category/index.tsx
+++ b/src/pages/category/index.tsx
@@ -1,4 +1,6 @@
+import type { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
+import type { DehydratedState } from '@tanstack/react-query';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { Flex, Spacing } from '@toss/emotion-utils';
 import { useRecoilValue } from 'recoil';
@@ -11,7 +13,7 @@ import { MAIN_CATEGORY_QUERY_KEYS } from '~/constants/queryKeys';
 import { useMainCategoryQuery } from '~/hooks/query/useMainCategoryQuery';
 import selectedCategoryIdAtomFamily from '~/store/selectedCategoryId/selectedCategoryIdAtom';
 
-export async function getStaticProps() {
+export const getStaticProps: GetStaticProps<{ dehydratedState: DehydratedState }> = async () => {
   const queryClient = new QueryClient();
 
   await queryClient.prefetchQuery(MAIN_CATEGORY_QUERY_KEYS.getMainCategories, getMainCategories);
@@ -21,7 +23,7 @@ export async function getStaticProps() {
       dehydratedState: dehydrate(queryClient),
     },
   };
-}
+};
 
 export default function Category() {
   const { data: mainCategoryData } = useMainCategoryQuery();

--- a/src/pages/category/index.tsx
+++ b/src/pages/category/index.tsx
@@ -16,7 +16,10 @@ import selectedCategoryIdAtomFamily from '~/store/selectedCategoryId/selectedCat
 export const getStaticProps: GetStaticProps<{ dehydratedState: DehydratedState }> = async () => {
   const queryClient = new QueryClient();
 
-  await queryClient.prefetchQuery(MAIN_CATEGORY_QUERY_KEYS.getMainCategories, getMainCategories);
+  await queryClient.prefetchQuery({
+    queryKey: MAIN_CATEGORY_QUERY_KEYS.getMainCategories,
+    queryFn: getMainCategories,
+  });
 
   return {
     props: {

--- a/src/types/response.d.ts
+++ b/src/types/response.d.ts
@@ -6,3 +6,13 @@ interface MainCategoryResponse {
 interface MainCategoriesResponse {
   categories: MainCategoryResponse[];
 }
+interface MidCategoryResponse {
+  id: number;
+  imageUrl: string;
+  name: string;
+}
+
+interface MidCategoriesResponse {
+  name: string;
+  categories: MidCategoryResponse[];
+}


### PR DESCRIPTION
## 🚀 작업 내용
<!-- 작업한 사항을 간략하게 적어주세요 -->
1. `Suspense` 문제를 임시로 해결했어요.
2. `Category Detail` 페이지를 완성했어요.


## ✏️ 상세 설명
<!-- 추가 설명이 필요한 경우 작성해주세요 -->
### 1. `suspense` 문제를 임시로 해결했어요.
- 페이지에 `api` 호출 로직이 있어 페이지 로딩시 `Global Suspense`가 발생하는 문제가 있어요.
- 각 화면에서 `api`를 호출하는 컴포넌트를 따로 분리하고 `Suspense`를 적용해줄 필요가 있어요. 
- `Global Suspense`의 `fallback` 컴포넌트를 `blank div`로 설정 해 임시 조치를 취했어요.
```diff
- <ClientSuspense fallback={<>Global Suspense</>}>
+ <ClientSuspense fallback={<></>}>
```
### 2. `category detail` 페이지를 완성했어요.
- 각 페이지를 `SSG`를 사용하여 생성했어요.
- `S3` 관련해서 서버와 이야기 후 `URL` 변경이 필요해요.

https://user-images.githubusercontent.com/79739512/224471237-871b4a41-9a80-4f36-8b83-bb1761d4c275.mov

<img width="715" alt="image" src="https://user-images.githubusercontent.com/79739512/224471174-162e2ecc-7647-4da9-8cef-e4d288512c27.png">



## 📷 스크린샷
<!-- 스크린샷으로 작업 내용을 알려주세요 -->
<img width="258" alt="image" src="https://user-images.githubusercontent.com/79739512/224471021-5846b714-b73c-4218-841c-b413b6e23949.png">


## 📁 참고 자료
<!-- 참고한 자료가 있다면 공유주세요 -->