### PR TITLE
setting: auto release tag action 추가

### DIFF
--- a/.github/workflows/auto-release-tag.yml
+++ b/.github/workflows/auto-release-tag.yml
@@ -1,0 +1,20 @@
+name: Auto Release Tag
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: 버전 정보 추출
+        run: echo "##[set-output name=version;]$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+        id: extract_version_name
+      - name: Release 생성
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.extract_version_name.outputs.version }}
+          release_name: ${{ steps.extract_version_name.outputs.version }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effective-tech-interview-client",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## 🚀 작업 내용
<!-- 작업한 사항을 간략하게 적어주세요 -->
1. `auto release tag` 생성을 위한 `action`을 추가했어요.

## ✏️ 상세 설명
<!-- 추가 설명이 필요한 경우 작성해주세요 -->
### 1. `auto release tag` 생성을 위한 `action`을 추가했어요.
- `main` 브런치에 `push`시 `action`이 발생해요.
- 마지막 커밋 이름을 `0.0.0` 같이 설정해야 `action`을 실행할 수 있어요.

## 📷 스크린샷
<!-- 스크린샷으로 작업 내용을 알려주세요 -->

## 📁 참고 자료
<!-- 참고한 자료가 있다면 공유주세요 -->
- [GitHub에서 Release/Tag 자동으로 만들어 주기(1분만에 설정)
](https://medium.com/prnd/github%EC%97%90%EC%84%9C-release-tag-%EC%9E%90%EB%8F%99%EC%9C%BC%EB%A1%9C-%EB%A7%8C%EB%93%A4%EC%96%B4-%EC%A3%BC%EA%B8%B0-1%EB%B6%84%EB%A7%8C%EC%97%90-%EC%84%A4%EC%A0%95-5c09a383fb08)