### PR TITLE
fix: auto release tag action permissions 추가

### DIFF
--- a/.github/workflows/auto-release-tag.yml
+++ b/.github/workflows/auto-release-tag.yml
@@ -4,7 +4,9 @@ on:
     branches:
       - main
 jobs:
-  build:
+  job_auto_release_tag:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## 🚀 작업 내용
<!-- 작업한 사항을 간략하게 적어주세요 -->
1. `auto release tag action`에 `permissions`을 추가했어요.

## ✏️ 상세 설명
<!-- 추가 설명이 필요한 경우 작성해주세요 -->
### 1. `auto release tag action`에 `permissions`을 추가했어요.
- 다음과 같이 액션이 실패했어요. [Relase 1.0.0 (#43)](https://github.com/effective-tech-interview/effective-tech-interview-client/actions/runs/4503842355)
- `PR labeler` 에서도 동일하게 발생한 문제로 `action` 토큰에 `permission` 문제로 보여요.

## 📷 스크린샷
<!-- 스크린샷으로 작업 내용을 알려주세요 -->
![image](https://user-images.githubusercontent.com/79739512/227414680-8f3cb8e8-2b1b-4c98-a09b-444ee065af28.png)

## 📁 참고 자료
<!-- 참고한 자료가 있다면 공유주세요 -->
- [Assigning permissions to jobs - Modify the default permissions granted to GITHUB_TOKEN.](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)
- [Permissions required for GitHub Apps - You can find the required permissions for each GitHub App-compatible endpoint.](https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28#contents)
- [What permissions does GITHUB_TOKEN require for releases from a GitHub Action](https://stackoverflow.com/questions/67389957/what-permissions-does-github-token-require-for-releases-from-a-github-action)
- [What is "contents: write" permission in GitHub workflow?](https://stackoverflow.com/questions/72110199/what-is-contents-write-permission-in-github-workflow)