### PR TITLE
fix: modal dimmed z-index 에러 해결

### DIFF
--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -47,9 +47,9 @@ const Dimmer = styled.div`
   height: 100%;
   top: 0%;
   background-color: rgba(0, 0, 0, 0.5);
+  z-index: 9999;
 
   ${theme.mediaQuery.desktop} {
     width: 360px;
-    z-index: 9999;
   }
 `;


### PR DESCRIPTION
## 🚀 작업 내용
<!-- 작업한 사항을 간략하게 적어주세요 -->
1. 면접 연습 끝내기 모달에서 `bubble` 화살표 꼬리가 `Dimmed` 처리되지 않는 문제를 해결했어요.

## ✏️ 상세 설명
<!-- 추가 설명이 필요한 경우 작성해주세요 -->
### 1. 면접 연습 끝내기 모달에서 `bubble` 화살표 꼬리가 `Dimmed` 처리되지 않는 문제를 해결했어요.
- `modal` `Dimmer`에 `z-index`를 추가했어요.

## 📷 스크린샷
<!-- 스크린샷으로 작업 내용을 알려주세요 -->
| Production | Development |
|---|---|
| ![image](https://user-images.githubusercontent.com/79739512/227754817-e21065b8-4fd8-439b-b2b5-b173945a3efb.png) | ![image](https://user-images.githubusercontent.com/79739512/227754829-5288c5ed-3981-4619-a00e-6de4e615a296.png) |


## 📁 참고 자료
<!-- 참고한 자료가 있다면 공유주세요 -->