### PR TITLE
feat: refreshToken cookie 변경사항 반영

### DIFF
--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -24,6 +24,7 @@ export const authToken = {
 
 export const axiosClient = axios.create({
   baseURL: process.env.NODE_ENV === 'development' ? DEV_SERVER_URL : PROD_SERVER_URL,
+  withCredentials: true,
   headers: {
     Authorization: `Bearer ${authToken.access}`,
     'Content-Type': 'application/json; charset=utf-8',
@@ -142,7 +143,6 @@ axiosClient.interceptors.request.use(
 axiosClient.interceptors.response.use(
   response => response,
   async function (error: EffError) {
-    console.log(error);
     if (isEffError(error) && error.errorCode === 401) {
       try {
         const {
@@ -156,7 +156,7 @@ axiosClient.interceptors.response.use(
           //localStorage에 새 토큰 저장
           localStorage.setItem('accessToken', accessToken);
           const originalResponse = await axios.request(error.config);
-          return originalResponse.data.data;
+          return originalResponse;
         }
       } catch (error: unknown) {
         if (error) {

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -5,7 +5,6 @@ import { authToken, axiosClient, PROD_SERVER_URL } from './client';
 export type LoginResponse = {
   memberId: number;
   accessToken: string;
-  refreshToken: string;
 };
 
 export async function postEmail(email: string) {
@@ -22,9 +21,9 @@ export async function postSignUp(email: string, password: string, confirmPasswor
 
 export async function postLogin(email: string, password: string) {
   const {
-    data: { memberId, accessToken, refreshToken },
+    data: { memberId, accessToken },
   } = await axiosClient.post<LoginResponse>('/v1/auth/login', { email, password });
-  return { memberId, accessToken, refreshToken };
+  return { memberId, accessToken };
 }
 
 //password reset apis
@@ -46,7 +45,6 @@ export async function postResetPassword(email: string, password: string, confirm
 export async function postLogout() {
   const headers = {
     Authorization: `Bearer ${authToken.access}`,
-    refreshToken: `Bearer ${authToken.refresh}`,
   };
 
   return await axios.post(`${PROD_SERVER_URL}/v1/auth/logout`, null, {

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-
-import { authToken, axiosClient, PROD_SERVER_URL } from './client';
+import { axiosClient } from './client';
 
 export type LoginResponse = {
   memberId: number;
@@ -43,13 +41,7 @@ export async function postResetPassword(email: string, password: string, confirm
 }
 
 export async function postLogout() {
-  const headers = {
-    Authorization: `Bearer ${authToken.access}`,
-  };
-
-  return await axios.post(`${PROD_SERVER_URL}/v1/auth/logout`, null, {
-    headers,
-  });
+  return await axiosClient.post('/v1/auth/logout');
 }
 
 export async function getUser() {

--- a/src/components/common/QueryClientProvider/QueryClientProvider.tsx
+++ b/src/components/common/QueryClientProvider/QueryClientProvider.tsx
@@ -24,6 +24,7 @@ const QueryClientProvider = ({
             suspense: true,
             useErrorBoundary: true,
             refetchOnWindowFocus: false,
+            retry: false,
           },
         },
       })

--- a/src/hooks/form/useCheckLoginForm.ts
+++ b/src/hooks/form/useCheckLoginForm.ts
@@ -50,9 +50,8 @@ export const useCheckLoginForm = () => {
     try {
       const data = await postLogin(email, password);
       if (data) {
-        const { accessToken, refreshToken } = data;
+        const { accessToken } = data;
         localStorage.setItem('accessToken', accessToken);
-        localStorage.setItem('refreshToken', refreshToken);
         router.push('/category');
       }
     } catch (error: unknown) {

--- a/src/hooks/form/useCheckLoginForm.ts
+++ b/src/hooks/form/useCheckLoginForm.ts
@@ -4,7 +4,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 
 import { postLogin } from '~/apis';
-import { isEffError } from '~/apis/client';
+import { authToken, isEffError } from '~/apis/client';
 import { emailPattern, passwordPattern } from '~/constants/validationPattern';
 
 import { useToast } from '../useToast';
@@ -48,6 +48,8 @@ export const useCheckLoginForm = () => {
   const { mutate: loginMutation } = useMutation(async () => {
     const { email, password } = getValues();
     try {
+      authToken.destroy();
+
       const data = await postLogin(email, password);
       if (data) {
         const { accessToken } = data;

--- a/src/hooks/useShowLoginModal.tsx
+++ b/src/hooks/useShowLoginModal.tsx
@@ -10,7 +10,7 @@ export function useShowLoginModal(redirectUrl?: string) {
   const router = useRouter();
 
   const showLoginModal = async () => {
-    if (authToken.access && authToken.refresh) {
+    if (authToken.access) {
       router.push(`/${redirectUrl}`);
     } else {
       await openModal({


### PR DESCRIPTION
## 🚀 작업 내용
<!-- 작업한 사항을 간략하게 적어주세요 -->
- refreshToken을 cookie로 주고받게 되어 클라이언트에서 refreshToken 관련 로직을 수정했습니다. 
- axios를 사용하는 경우 모두 기존에 만들어둔 axios instance를 사용하도록 수정했습니다. 
- cookie를 사용하여 백과 통신하기 위해 `withCredentials: true` 설정을 axios instance 내부에 추가했습니다. 
- react query 사용 시, 통신이 실패할 때 불필요한 refetch 로직이 많아지는 것 같아 `retry: false` 설정을 queryclient에 추가했습니다. 

## ✏️ 상세 설명
<!-- 추가 설명이 필요한 경우 작성해주세요 -->


## 📷 스크린샷
<!-- 스크린샷으로 작업 내용을 알려주세요 -->

## 📁 참고 자료
<!-- 참고한 자료가 있다면 공유주세요 -->